### PR TITLE
[#IOINFRA-48] Update fn-pushnotifications config

### DIFF
--- a/azure-devops/projects/io-backend-projects/io-functions-pushnotifications.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-pushnotifications.tf
@@ -97,11 +97,6 @@ resource "azuredevops_build_definition" "io-functions-pushnotifications-deploy" 
   }
 
   variable {
-    name  = "NPM_CONNECTION"
-    value = azuredevops_serviceendpoint_npm.pagopa-npm-bot.service_endpoint_name
-  }
-
-  variable {
     name  = "CACHE_VERSION_ID"
     value = var.io-functions-pushnotifications.pipeline.cache_version_id
   }
@@ -128,16 +123,6 @@ resource "azuredevops_resource_authorization" "io-functions-pushnotifications-de
 
   project_id    = azuredevops_project.project.id
   resource_id   = azuredevops_serviceendpoint_github.io-azure-devops-github-rw.id
-  definition_id = azuredevops_build_definition.io-functions-pushnotifications-deploy.id
-  authorized    = true
-  type          = "endpoint"
-}
-
-resource "azuredevops_resource_authorization" "io-functions-pushnotifications-deploy-npm-auth" {
-  depends_on = [azuredevops_serviceendpoint_npm.pagopa-npm-bot, azuredevops_build_definition.io-functions-pushnotifications-deploy, azuredevops_project.project]
-
-  project_id    = azuredevops_project.project.id
-  resource_id   = azuredevops_serviceendpoint_npm.pagopa-npm-bot.id
   definition_id = azuredevops_build_definition.io-functions-pushnotifications-deploy.id
   authorized    = true
   type          = "endpoint"

--- a/azure-devops/projects/io-backend-projects/io-functions-pushnotifications.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-pushnotifications.tf
@@ -7,7 +7,7 @@ variable "io-functions-pushnotifications" {
       pipelines_path = ".devops"
     }
     pipeline = {
-      production_resource_group_name = "io-p-rg-internal"
+      production_resource_group_name = "io-p-rg-notifications"
       production_app_name            = "io-p-fn3-pushnotif"
       cache_version_id               = "v1"
     }
@@ -97,6 +97,11 @@ resource "azuredevops_build_definition" "io-functions-pushnotifications-deploy" 
   }
 
   variable {
+    name  = "NPM_CONNECTION"
+    value = azuredevops_serviceendpoint_npm.pagopa-npm-bot.service_endpoint_name
+  }
+
+  variable {
     name  = "CACHE_VERSION_ID"
     value = var.io-functions-pushnotifications.pipeline.cache_version_id
   }
@@ -123,6 +128,16 @@ resource "azuredevops_resource_authorization" "io-functions-pushnotifications-de
 
   project_id    = azuredevops_project.project.id
   resource_id   = azuredevops_serviceendpoint_github.io-azure-devops-github-rw.id
+  definition_id = azuredevops_build_definition.io-functions-pushnotifications-deploy.id
+  authorized    = true
+  type          = "endpoint"
+}
+
+resource "azuredevops_resource_authorization" "io-functions-pushnotifications-deploy-npm-auth" {
+  depends_on = [azuredevops_serviceendpoint_npm.pagopa-npm-bot, azuredevops_build_definition.io-functions-pushnotifications-deploy, azuredevops_project.project]
+
+  project_id    = azuredevops_project.project.id
+  resource_id   = azuredevops_serviceendpoint_npm.pagopa-npm-bot.id
   definition_id = azuredevops_build_definition.io-functions-pushnotifications-deploy.id
   authorized    = true
   type          = "endpoint"

--- a/azure-devops/projects/io-backend-projects/provider.tf
+++ b/azure-devops/projects/io-backend-projects/provider.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 0.1.3"
+      version = "= 0.1.3"
     }
     azurerm = {
       version = "~> 2.52.0"

--- a/azure-devops/projects/io-backend-projects/secrets.tf
+++ b/azure-devops/projects/io-backend-projects/secrets.tf
@@ -10,6 +10,7 @@ variable "secrets" {
     "io-azure-devops-github-pr-TOKEN",
     "io-azure-devops-github-EMAIL",
     "io-azure-devops-github-USERNAME",
+    "pagopa-npm-bot-TOKEN",
     "TTDIO-PROD-IO-SUBSCRIPTION-ID",
     "TTDIO-DEV-IO-SUBSCRIPTION-ID",
     "TTDIO-SPN-TENANTID",

--- a/azure-devops/projects/io-backend-projects/service_connections.tf
+++ b/azure-devops/projects/io-backend-projects/service_connections.tf
@@ -77,3 +77,13 @@ resource "azuredevops_serviceendpoint_github" "pagopa" {
     ignore_changes = [description, authorization]
   }
 }
+
+# npm service connection
+resource "azuredevops_serviceendpoint_npm" "pagopa-npm-bot" {
+  depends_on = [azuredevops_project.project]
+
+  project_id            = azuredevops_project.project.id
+  service_endpoint_name = "pagopa-npm-bot"
+  url                   = "https://registry.npmjs.org"
+  access_token          = data.azurerm_key_vault_secret.key_vault_secret["pagopa-npm-bot-TOKEN"].value
+}


### PR DESCRIPTION
This PR need to set `pagopa-npm-bot-TOKEN` secret into keyvault

1. change resource group to `io-p-rg-notifications`
2. add npm service endpoint `pagopa-npm-bot`
3. set azuredevops provider to `version = 0.1.3` instead of `version ~> 0.1.3`

Status: not applied

To apply this pr is required to install custom azuredevops terraform provider. Here how to install it https://github.com/pagopa/gitops/tree/IO-19-add-readme-azdevops/azure-devops#how-to-install-custom-provider