### PR TITLE
io-backend-projects fix pipelines variables

### DIFF
--- a/azure-devops/projects/io-backend-projects/io-backend.tf
+++ b/azure-devops/projects/io-backend-projects/io-backend.tf
@@ -12,7 +12,11 @@ variable "io-backend" {
   }
 }
 
-# code review
+#
+# Code Review pipeline
+#
+
+# Define code review pipeline
 resource "azuredevops_build_definition" "io-backend-code-review" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-pr, azuredevops_project.project]
 
@@ -53,7 +57,7 @@ resource "azuredevops_build_definition" "io-backend-code-review" {
   }
 }
 
-# code review serviceendpoint authorization
+# Allow code review pipeline to access Github readonly service connection, needed to access external templates to be used inside the pipeline
 resource "azuredevops_resource_authorization" "io-backend-code-review-github-ro-auth" {
   depends_on = [azuredevops_serviceendpoint_github.pagopa, azuredevops_build_definition.io-backend-code-review, azuredevops_project.project]
 
@@ -64,6 +68,7 @@ resource "azuredevops_resource_authorization" "io-backend-code-review-github-ro-
   type          = "endpoint"
 }
 
+# Allow code review pipeline to access Github pr service connection, needed to checkout code from the pull request branch
 resource "azuredevops_resource_authorization" "io-backend-code-review-github-pr-auth" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-pr, azuredevops_build_definition.io-backend-code-review, azuredevops_project.project]
 
@@ -74,7 +79,11 @@ resource "azuredevops_resource_authorization" "io-backend-code-review-github-pr-
   type          = "endpoint"
 }
 
-# deploy
+#
+# Deploy pipeline
+#
+
+# Define deploy pipeline
 resource "azuredevops_build_definition" "io-backend-deploy" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-rw, azuredevops_serviceendpoint_azurerm.PROD-IO, azuredevops_project.project]
 
@@ -116,7 +125,7 @@ resource "azuredevops_build_definition" "io-backend-deploy" {
   }
 }
 
-# deploy serviceendpoint authorization
+# Allow deploy pipeline to access Github readonly service connection, needed to access external templates to be used inside the pipeline
 resource "azuredevops_resource_authorization" "io-backend-deploy-github-ro-auth" {
   depends_on = [azuredevops_serviceendpoint_github.pagopa, azuredevops_build_definition.io-backend-deploy, azuredevops_project.project]
 
@@ -127,6 +136,7 @@ resource "azuredevops_resource_authorization" "io-backend-deploy-github-ro-auth"
   type          = "endpoint"
 }
 
+# Allow deploy pipeline to access Github writable service connection, needed to bump project version and publish a new relase
 resource "azuredevops_resource_authorization" "io-backend-deploy-github-rw-auth" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-rw, azuredevops_build_definition.io-backend-deploy, azuredevops_project.project]
 
@@ -137,6 +147,7 @@ resource "azuredevops_resource_authorization" "io-backend-deploy-github-rw-auth"
   type          = "endpoint"
 }
 
+# Allow deploy pipeline to access Azure PROD-IO subscription service connection, needed to interact with Azure resources
 resource "azuredevops_resource_authorization" "io-backend-deploy-azurerm-PROD-IO-auth" {
   depends_on = [azuredevops_serviceendpoint_azurerm.PROD-IO, azuredevops_build_definition.io-backend-deploy, time_sleep.wait]
 

--- a/azure-devops/projects/io-backend-projects/io-functions-admin.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-admin.tf
@@ -7,7 +7,9 @@ variable "io-functions-admin" {
       pipelines_path = ".devops"
     }
     pipeline = {
-      cache_version_id = "v3"
+      cache_version_id               = "v3"
+      production_resource_group_name = "io-p-rg-internal"
+      production_app_name            = "io-p-fn3-admin"
     }
   }
 }
@@ -127,6 +129,16 @@ resource "azuredevops_build_definition" "io-functions-admin-deploy" {
   variable {
     name  = "PRODUCTION_AZURE_SUBSCRIPTION"
     value = azuredevops_serviceendpoint_azurerm.PROD-IO.service_endpoint_name
+  }
+
+  variable {
+    name  = "PRODUCTION_APP_NAME"
+    value = var.io-functions-admin.pipeline.production_app_name
+  }
+
+  variable {
+    name  = "PRODUCTION_RESOURCE_GROUP_NAME"
+    value = var.io-functions-admin.pipeline.production_resource_group_name
   }
 }
 

--- a/azure-devops/projects/io-backend-projects/io-functions-assets.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-assets.tf
@@ -7,7 +7,9 @@ variable "io-functions-assets" {
       pipelines_path = ".devops"
     }
     pipeline = {
-      cache_version_id = "v3"
+      cache_version_id               = "v3"
+      production_resource_group_name = "io-p-rg-internal"
+      production_app_name            = "io-p-fn3-assets"
     }
   }
 }
@@ -122,6 +124,16 @@ resource "azuredevops_build_definition" "io-functions-assets-deploy" {
   variable {
     name  = "PRODUCTION_AZURE_SUBSCRIPTION"
     value = azuredevops_serviceendpoint_azurerm.PROD-IO.service_endpoint_name
+  }
+
+  variable {
+    name  = "PRODUCTION_APP_NAME"
+    value = var.io-functions-assets.pipeline.production_app_name
+  }
+
+  variable {
+    name  = "PRODUCTION_RESOURCE_GROUP_NAME"
+    value = var.io-functions-assets.pipeline.production_resource_group_name
   }
 }
 

--- a/azure-devops/projects/io-backend-projects/io-functions-public.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-public.tf
@@ -7,7 +7,9 @@ variable "io-functions-public" {
       pipelines_path = ".devops"
     }
     pipeline = {
-      cache_version_id = "v3"
+      cache_version_id               = "v3"
+      production_resource_group_name = "io-p-rg-internal"
+      production_app_name            = "io-p-fn3-public"
     }
   }
 }
@@ -122,6 +124,16 @@ resource "azuredevops_build_definition" "io-functions-public-deploy" {
   variable {
     name  = "PRODUCTION_AZURE_SUBSCRIPTION"
     value = azuredevops_serviceendpoint_azurerm.PROD-IO.service_endpoint_name
+  }
+
+  variable {
+    name  = "PRODUCTION_APP_NAME"
+    value = var.io-functions-public.pipeline.production_app_name
+  }
+
+  variable {
+    name  = "PRODUCTION_RESOURCE_GROUP_NAME"
+    value = var.io-functions-public.pipeline.production_resource_group_name
   }
 }
 

--- a/azure-devops/projects/io-backend-projects/io-functions-pushnotifications.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-pushnotifications.tf
@@ -7,14 +7,18 @@ variable "io-functions-pushnotifications" {
       pipelines_path = ".devops"
     }
     pipeline = {
+      cache_version_id               = "v3"
       production_resource_group_name = "io-p-rg-notifications"
       production_app_name            = "io-p-fn3-pushnotif"
-      cache_version_id               = "v1"
     }
   }
 }
 
-# code review
+#
+# Code Review pipeline
+#
+
+# Define code review pipeline
 resource "azuredevops_build_definition" "io-functions-pushnotifications-code-review" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-pr, azuredevops_project.project]
 
@@ -55,7 +59,7 @@ resource "azuredevops_build_definition" "io-functions-pushnotifications-code-rev
   }
 }
 
-# code review serviceendpoint authorization
+# Allow code review pipeline to access Github readonly service connection, needed to access external templates to be used inside the pipeline
 resource "azuredevops_resource_authorization" "io-functions-pushnotifications-code-review-github-ro-auth" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-ro, azuredevops_build_definition.io-functions-pushnotifications-code-review, azuredevops_project.project]
 
@@ -66,6 +70,7 @@ resource "azuredevops_resource_authorization" "io-functions-pushnotifications-co
   type          = "endpoint"
 }
 
+# Allow code review pipeline to access Github pr service connection, needed to checkout code from the pull request branch
 resource "azuredevops_resource_authorization" "io-functions-pushnotifications-code-review-github-pr-auth" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-pr, azuredevops_build_definition.io-functions-pushnotifications-code-review, azuredevops_project.project]
 
@@ -76,7 +81,11 @@ resource "azuredevops_resource_authorization" "io-functions-pushnotifications-co
   type          = "endpoint"
 }
 
-# deploy
+#
+# Deploy pipeline
+#
+
+# Define deploy pipeline
 resource "azuredevops_build_definition" "io-functions-pushnotifications-deploy" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-rw, azuredevops_serviceendpoint_azurerm.PROD-IO, azuredevops_project.project]
 
@@ -129,7 +138,7 @@ resource "azuredevops_build_definition" "io-functions-pushnotifications-deploy" 
 
 }
 
-# deploy serviceendpoint authorization
+# Allow deploy pipeline to access Github readonly service connection, needed to access external templates to be used inside the pipeline
 resource "azuredevops_resource_authorization" "io-functions-pushnotifications-deploy-github-ro-auth" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-ro, azuredevops_build_definition.io-functions-pushnotifications-deploy, azuredevops_project.project]
 
@@ -140,6 +149,7 @@ resource "azuredevops_resource_authorization" "io-functions-pushnotifications-de
   type          = "endpoint"
 }
 
+# Allow deploy pipeline to access Github writable service connection, needed to bump project version and publish a new relase
 resource "azuredevops_resource_authorization" "io-functions-pushnotifications-deploy-github-rw-auth" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-rw, azuredevops_build_definition.io-functions-pushnotifications-deploy, azuredevops_project.project]
 
@@ -150,6 +160,7 @@ resource "azuredevops_resource_authorization" "io-functions-pushnotifications-de
   type          = "endpoint"
 }
 
+# Allow deploy pipeline to access Azure PROD-IO subscription service connection, needed to interact with Azure resources
 resource "azuredevops_resource_authorization" "io-functions-pushnotifications-deploy-azurerm-PROD-IO-auth" {
   depends_on = [azuredevops_serviceendpoint_azurerm.PROD-IO, azuredevops_build_definition.io-functions-pushnotifications-deploy, time_sleep.wait]
 

--- a/azure-devops/projects/io-backend-projects/io-functions-services-cache.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-services-cache.tf
@@ -7,14 +7,18 @@ variable "io-functions-services-cache" {
       pipelines_path = ".devops"
     }
     pipeline = {
+      cache_version_id               = "v3"
       production_resource_group_name = "io-p-rg-internal"
       production_app_name            = "io-p-fn3-servicescache"
-      cache_version_id               = "v1"
     }
   }
 }
 
-# code review
+#
+# Code Review pipeline
+#
+
+# Define code review pipeline
 resource "azuredevops_build_definition" "io-functions-services-cache-code-review" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-pr, azuredevops_project.project]
 
@@ -55,7 +59,7 @@ resource "azuredevops_build_definition" "io-functions-services-cache-code-review
   }
 }
 
-# code review serviceendpoint authorization
+# Allow code review pipeline to access Github readonly service connection, needed to access external templates to be used inside the pipeline
 resource "azuredevops_resource_authorization" "io-functions-services-cache-code-review-github-ro-auth" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-ro, azuredevops_build_definition.io-functions-services-cache-code-review, azuredevops_project.project]
 
@@ -66,6 +70,7 @@ resource "azuredevops_resource_authorization" "io-functions-services-cache-code-
   type          = "endpoint"
 }
 
+# Allow code review pipeline to access Github pr service connection, needed to checkout code from the pull request branch
 resource "azuredevops_resource_authorization" "io-functions-services-cache-code-review-github-pr-auth" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-pr, azuredevops_build_definition.io-functions-services-cache-code-review, azuredevops_project.project]
 
@@ -76,7 +81,11 @@ resource "azuredevops_resource_authorization" "io-functions-services-cache-code-
   type          = "endpoint"
 }
 
-# deploy
+#
+# Deploy pipeline
+#
+
+# Define deploy pipeline
 resource "azuredevops_build_definition" "io-functions-services-cache-deploy" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-rw, azuredevops_serviceendpoint_azurerm.PROD-IO, azuredevops_project.project]
 
@@ -129,7 +138,7 @@ resource "azuredevops_build_definition" "io-functions-services-cache-deploy" {
 
 }
 
-# deploy serviceendpoint authorization
+# Allow deploy pipeline to access Github readonly service connection, needed to access external templates to be used inside the pipeline
 resource "azuredevops_resource_authorization" "io-functions-services-cache-deploy-github-ro-auth" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-ro, azuredevops_build_definition.io-functions-services-cache-deploy, azuredevops_project.project]
 
@@ -140,6 +149,7 @@ resource "azuredevops_resource_authorization" "io-functions-services-cache-deplo
   type          = "endpoint"
 }
 
+# Allow deploy pipeline to access Github writable service connection, needed to bump project version and publish a new relase
 resource "azuredevops_resource_authorization" "io-functions-services-cache-deploy-github-rw-auth" {
   depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-rw, azuredevops_build_definition.io-functions-services-cache-deploy, azuredevops_project.project]
 
@@ -150,6 +160,7 @@ resource "azuredevops_resource_authorization" "io-functions-services-cache-deplo
   type          = "endpoint"
 }
 
+# Allow deploy pipeline to access Azure PROD-IO subscription service connection, needed to interact with Azure resources
 resource "azuredevops_resource_authorization" "io-functions-services-cache-deploy-azurerm-PROD-IO-auth" {
   depends_on = [azuredevops_serviceendpoint_azurerm.PROD-IO, azuredevops_build_definition.io-functions-services-cache-deploy, time_sleep.wait]
 

--- a/azure-devops/projects/io-backend-projects/io-functions-services.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-services.tf
@@ -7,7 +7,9 @@ variable "io-functions-services" {
       pipelines_path = ".devops"
     }
     pipeline = {
-      cache_version_id = "v3"
+      cache_version_id               = "v3"
+      production_resource_group_name = "io-p-rg-internal"
+      production_app_name            = "io-p-fn3-services"
     }
   }
 }
@@ -127,6 +129,16 @@ resource "azuredevops_build_definition" "io-functions-services-deploy" {
   variable {
     name  = "PRODUCTION_AZURE_SUBSCRIPTION"
     value = azuredevops_serviceendpoint_azurerm.PROD-IO.service_endpoint_name
+  }
+
+  variable {
+    name  = "PRODUCTION_APP_NAME"
+    value = var.io-functions-services.pipeline.production_app_name
+  }
+
+  variable {
+    name  = "PRODUCTION_RESOURCE_GROUP_NAME"
+    value = var.io-functions-services.pipeline.production_resource_group_name
   }
 }
 


### PR DESCRIPTION
this pr fix missing `production_resource_group_name` and `production_app_name` variables

```
    pipeline = {
      cache_version_id               = "v3"
      production_resource_group_name = "io-p-rg-internal"
      production_app_name            = "io-p-fn3-admin"
    }
```

Also adds standard comments