### PR TITLE
[#IP-103] (+) add yarn-lock-upgrade resource to pushnotification terraform script

### DIFF
--- a/azure-devops/projects/io-backend-projects/io-functions-pushnotifications.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-pushnotifications.tf
@@ -15,6 +15,37 @@ variable "io-functions-pushnotifications" {
 }
 
 #
+# Yarn.lock Upgrade pipeline
+#
+
+# Define Yarn.lock Upgrade pipeline
+resource "azuredevops_build_definition" "io-functions-pushnotifications-yarn-lock-upgrade" {
+  depends_on = [azuredevops_serviceendpoint_github.io-azure-devops-github-pr, azuredevops_project.project]
+  
+  project_id = azuredevops_project.project.id
+  name       = "${var.io-functions-pushnotifications.repository.name}.yarn-lock-upgrade"
+  path       = "\\${var.io-functions-pushnotifications.repository.name}"
+
+  repository {
+    repo_type             = "GitHub"
+    repo_id               = "${var.io-functions-pushnotifications.repository.organization}/${var.io-functions-pushnotifications.repository.name}"
+    branch_name           = var.io-functions-pushnotifications.repository.branch_name
+    yml_path              = "${var.io-functions-pushnotifications.repository.pipelines_path}/yarn-lock-upgrade.yml"
+    service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-pr.id
+  }
+
+  variable {
+    name  = "GITHUB_EMAIL"
+    value = data.azurerm_key_vault_secret.key_vault_secret["io-azure-devops-github-EMAIL"].value
+  }
+
+  variable {
+    name  = "GITHUB_USERNAME"
+    value = data.azurerm_key_vault_secret.key_vault_secret["io-azure-devops-github-USERNAME"].value
+  }
+}
+
+#
 # Code Review pipeline
 #
 


### PR DESCRIPTION
The current devops pipelines never update the dependency versions locked in the yarn.lock file. 
The PR add to the terragrunt script for pushnotification pipeline the yarn upgrade yob configured in the yarn-lock-upgrade.yml project file (based on the template yarn-lock-upgrade/template.yaml from the azure-pipeline-templates).
With this new pipeline, the locked dependecy versions will be re-generated every day.