### PR TITLE
remove inital branch filter from pr triggers

### DIFF
--- a/azure-devops/projects/io-backend-projects/io-backend.tf
+++ b/azure-devops/projects/io-backend-projects/io-backend.tf
@@ -25,7 +25,7 @@ resource "azuredevops_build_definition" "io-backend-code-review" {
   path       = "\\${var.io-backend.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-backend.repository.branch_name
+
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-backend-projects/io-functions-admin.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-admin.tf
@@ -27,7 +27,6 @@ resource "azuredevops_build_definition" "io-functions-admin-code-review" {
   path       = "\\${var.io-functions-admin.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-functions-admin.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-backend-projects/io-functions-app.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-app.tf
@@ -25,7 +25,6 @@ resource "azuredevops_build_definition" "io-functions-app-code-review" {
   path       = "\\${var.io-functions-app.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-functions-app.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-backend-projects/io-functions-assets.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-assets.tf
@@ -27,7 +27,6 @@ resource "azuredevops_build_definition" "io-functions-assets-code-review" {
   path       = "\\${var.io-functions-assets.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-functions-assets.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-backend-projects/io-functions-cgn-merchant.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-cgn-merchant.tf
@@ -27,7 +27,6 @@ resource "azuredevops_build_definition" "io-functions-cgn-merchant-code-review" 
   path       = "\\${var.io-functions-cgn-merchant.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-functions-cgn-merchant.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-backend-projects/io-functions-cgn.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-cgn.tf
@@ -27,7 +27,6 @@ resource "azuredevops_build_definition" "io-functions-cgn-code-review" {
   path       = "\\${var.io-functions-cgn.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-functions-cgn.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-backend-projects/io-functions-commons.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-commons.tf
@@ -25,7 +25,6 @@ resource "azuredevops_build_definition" "io-functions-commons-code-review" {
   path       = "\\${var.io-functions-commons.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-functions-commons.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-backend-projects/io-functions-public.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-public.tf
@@ -27,7 +27,6 @@ resource "azuredevops_build_definition" "io-functions-public-code-review" {
   path       = "\\${var.io-functions-public.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-functions-public.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-backend-projects/io-functions-pushnotifications.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-pushnotifications.tf
@@ -27,7 +27,6 @@ resource "azuredevops_build_definition" "io-functions-pushnotifications-code-rev
   path       = "\\${var.io-functions-pushnotifications.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-functions-pushnotifications.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-backend-projects/io-functions-services-cache.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-services-cache.tf
@@ -27,7 +27,6 @@ resource "azuredevops_build_definition" "io-functions-services-cache-code-review
   path       = "\\${var.io-functions-services-cache.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-functions-services-cache.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-backend-projects/io-functions-services.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-services.tf
@@ -27,7 +27,6 @@ resource "azuredevops_build_definition" "io-functions-services-code-review" {
   path       = "\\${var.io-functions-services.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-functions-services.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-backend-projects/io-pagopa-proxy.tf
+++ b/azure-devops/projects/io-backend-projects/io-pagopa-proxy.tf
@@ -28,7 +28,6 @@ resource "azuredevops_build_definition" "io-pagopa-proxy-code-review" {
   path       = "\\${var.io-pagopa-proxy.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-pagopa-proxy.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-developer-portal-projects/io-developer-portal-backend.tf
+++ b/azure-devops/projects/io-developer-portal-projects/io-developer-portal-backend.tf
@@ -31,7 +31,6 @@ resource "azuredevops_build_definition" "io-developer-portal-backend-code-review
   path       = "\\${var.io-developer-portal-backend.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-developer-portal-backend.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-developer-portal-projects/io-developer-portal-frontend.tf
+++ b/azure-devops/projects/io-developer-portal-projects/io-developer-portal-frontend.tf
@@ -40,7 +40,6 @@ resource "azuredevops_build_definition" "io-developer-portal-frontend-code-revie
   path       = "\\${var.io-developer-portal-frontend.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-developer-portal-frontend.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/io-services-metadata-projects/io-services-metadata.tf
+++ b/azure-devops/projects/io-services-metadata-projects/io-services-metadata.tf
@@ -25,7 +25,6 @@ resource "azuredevops_build_definition" "io-services-metadata" {
   path       = format("\\%s", var.io-services-metadata.repository.name)
 
   pull_request_trigger {
-    initial_branch = var.io-services-metadata.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/pagopa-packages-projects/io-spid-commons.tf
+++ b/azure-devops/projects/pagopa-packages-projects/io-spid-commons.tf
@@ -25,7 +25,6 @@ resource "azuredevops_build_definition" "io-spid-commons-code-review" {
   path       = "\\${var.io-spid-commons.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.io-spid-commons.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/pagopa-packages-projects/openapi-codegen-ts.tf
+++ b/azure-devops/projects/pagopa-packages-projects/openapi-codegen-ts.tf
@@ -25,7 +25,6 @@ resource "azuredevops_build_definition" "openapi-codegen-ts-code-review" {
   path       = "\\${var.openapi-codegen-ts.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.openapi-codegen-ts.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false

--- a/azure-devops/projects/pagopa-packages-projects/ts-commons.tf
+++ b/azure-devops/projects/pagopa-packages-projects/ts-commons.tf
@@ -29,7 +29,6 @@ resource "azuredevops_build_definition" "ts-commons-code-review" {
   path       = "\\${var.ts-commons.repository.name}"
 
   pull_request_trigger {
-    initial_branch = var.ts-commons.repository.branch_name
     forks {
       enabled       = false
       share_secrets = false


### PR DESCRIPTION
There are scenarios in which we open a PR towards a branch other than main/master. Such cases are rare but still they happen. An example: https://github.com/pagopa/io-functions-commons/pull/208

With the actual configuration, code review pipelines aren't triggered as the trigger is configured to respond to main branch only. 

Do we need this strictness? If no, I propose we remove such filter to allow any PR to run automatic tests.