### PR TITLE
[IOPAY-262] api-test pipeline for pagopa-payments-tests

### DIFF
--- a/azure-devops/projects/pagopa-projects/pagopa-payments-tests.tf
+++ b/azure-devops/projects/pagopa-projects/pagopa-payments-tests.tf
@@ -31,7 +31,8 @@ locals {
   pagopa-payments-tests-variables_secret_code_review = {
 
   }
-  
+}
+
 module "pagopa-payments-tests_code_review" {
   source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_code_review?ref=v1.0.0"
   count  = var.pagopa-payments-tests.pipeline.enable_code_review == true ? 1 : 0

--- a/azure-devops/projects/pagopa-projects/pagopa-payments-tests.tf
+++ b/azure-devops/projects/pagopa-projects/pagopa-payments-tests.tf
@@ -8,7 +8,7 @@ variable "pagopa-payments-tests" {
       yml_prefix_name = null
     }
     pipeline = {
-      enable_api_tests = true
+      enable_code_review = true
     }
   }
 }
@@ -23,18 +23,18 @@ locals {
   pagopa-payments-tests-variables_secret = {
 
   }
-  # api-tests vars
-  pagopa-payments-tests-variables_api_tests = {
+  # code_review vars
+  pagopa-payments-tests-variables_code_review = {
     danger_github_api_token = "skip"
   }
   # api-tests secrets
-  pagopa-payments-tests-variables_secret_api_tests = {
+  pagopa-payments-tests-variables_secret_code_review = {
 
   }
   
-module "pagopa-payments-tests_api_tests" {
+module "pagopa-payments-tests_code_review" {
   source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_code_review?ref=v1.0.0"
-  count  = var.pagopa-payments-tests.pipeline.enable_api_tests == true ? 1 : 0
+  count  = var.pagopa-payments-tests.pipeline.enable_code_review == true ? 1 : 0
 
   project_id                   = azuredevops_project.project.id
   repository                   = var.pagopa-payments-tests.repository
@@ -42,12 +42,12 @@ module "pagopa-payments-tests_api_tests" {
 
   variables = merge(
     local.pagopa-payments-tests-variables,
-    local.pagopa-payments-tests-variables_api_tests,
+    local.pagopa-payments-tests-variables_code_review,
   )
 
   variables_secret = merge(
     local.pagopa-payments-tests-variables_secret,
-    local.pagopa-payments-tests-variables_secret_api_tests,
+    local.pagopa-payments-tests-variables_secret_code_review,
   )
 
   service_connection_ids_authorization = [

--- a/azure-devops/projects/pagopa-projects/pagopa-payments-tests.tf
+++ b/azure-devops/projects/pagopa-projects/pagopa-payments-tests.tf
@@ -39,7 +39,7 @@ module "pagopa-payments-tests_code_review" {
 
   project_id                   = azuredevops_project.project.id
   repository                   = var.pagopa-payments-tests.repository
-  github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-pr.id
+  github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-rw.id
 
   variables = merge(
     local.pagopa-payments-tests-variables,

--- a/azure-devops/projects/pagopa-projects/pagopa-payments-tests.tf
+++ b/azure-devops/projects/pagopa-projects/pagopa-payments-tests.tf
@@ -1,0 +1,56 @@
+variable "pagopa-payments-tests" {
+  default = {
+    repository = {
+      organization    = "pagopa"
+      name            = "pagopa-payments-tests"
+      branch_name     = "main"
+      pipelines_path  = ".devops"
+      yml_prefix_name = null
+    }
+    pipeline = {
+      enable_api_tests = true
+    }
+  }
+}
+
+locals {
+  # global vars
+  pagopa-payments-tests-variables = {
+    cache_version_id = "v1"
+    default_branch   = var.pagopa-payments-tests.repository.branch_name
+  }
+  # global secrets
+  pagopa-payments-tests-variables_secret = {
+
+  }
+  # api-tests vars
+  pagopa-payments-tests-variables_api_tests = {
+    danger_github_api_token = "skip"
+  }
+  # api-tests secrets
+  pagopa-payments-tests-variables_secret_api_tests = {
+
+  }
+  
+module "pagopa-payments-tests_api_tests" {
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_code_review?ref=v1.0.0"
+  count  = var.pagopa-payments-tests.pipeline.enable_api_tests == true ? 1 : 0
+
+  project_id                   = azuredevops_project.project.id
+  repository                   = var.pagopa-payments-tests.repository
+  github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-pr.id
+
+  variables = merge(
+    local.pagopa-payments-tests-variables,
+    local.pagopa-payments-tests-variables_api_tests,
+  )
+
+  variables_secret = merge(
+    local.pagopa-payments-tests-variables_secret,
+    local.pagopa-payments-tests-variables_secret_api_tests,
+  )
+
+  service_connection_ids_authorization = [
+    azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id,
+  ]
+}


### PR DESCRIPTION
### List of changes

1. add a new pipeline configuration in `pagopa-projects` in order to run api test according to the pipeline defined in https://github.com/pagopa/pagopa-payments-tests/tree/main/.devops