### PR TITLE
Refine ownership per project

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@ azure-devops/projects/io-backend-projects/ @pagopa/io-backend-contributors
 azure-devops/projects/pagopa-packages-projects/ @pagopa/io-backend-contributors
 azure-devops/projects/cgn-onboarding-portal-projects/ @pagopa/carta-nazionale-giovani
 azure-devops/projects/io-app-projects/ @pagopa/io-app
-azure-devops/projec ts/io-services-metadata-projects/ @pagopa/io-backend-contributors
+azure-devops/projects/io-services-metadata-projects/ @pagopa/io-backend-contributors
 
 # TODO: create proper groups for the following projects
 azure-devops/projects/eucovidcert-projects/ @pagopa/io-backend-contributors

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,15 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
 
-* @pasqualedevita @uolter @balanza
+# Mainteiners of the whole repo
+* @pasqualedevita @uolter
+
+# Maintainers by specific project
+azure-devops/projects/io-backend-projects/ @pagopa/io-backend-contributors
+azure-devops/projects/pagopa-packages-projects/ @pagopa/io-backend-contributors
+azure-devops/projects/cgn-onboarding-portal-projects/ @pagopa/carta-nazionale-giovani
+azure-devops/projects/io-app-projects/ @pagopa/io-app
+azure-devops/projec ts/io-services-metadata-projects/ @pagopa/io-backend-contributors
+
+# TODO: create proper groups for the following projects
+azure-devops/projects/eucovidcert-projects/ @pagopa/io-backend-contributors
+azure-devops/projects/io-developer-portal-projects/ @pagopa/io-backend-contributors 


### PR DESCRIPTION
The purpose is to have a fine-grained ownership of the repo, so that each team can be independent in managing its own configurations while keeping control of them.

The solution is to assign sub-folders to relative github group