### PR TITLE
Revert "Refine ownership per project (#136)"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,15 +1,3 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
 
-# Mainteiners of the whole repo
-* @pasqualedevita @uolter
-
-# Maintainers by specific project
-azure-devops/projects/io-backend-projects/ @pagopa/io-backend-contributors
-azure-devops/projects/pagopa-packages-projects/ @pagopa/io-backend-contributors
-azure-devops/projects/cgn-onboarding-portal-projects/ @pagopa/carta-nazionale-giovani
-azure-devops/projects/io-app-projects/ @pagopa/io-app
-azure-devops/projects/io-services-metadata-projects/ @pagopa/io-backend-contributors
-
-# TODO: create proper groups for the following projects
-azure-devops/projects/eucovidcert-projects/ @pagopa/io-backend-contributors
-azure-devops/projects/io-developer-portal-projects/ @pagopa/io-backend-contributors 
+* @pasqualedevita @uolter @balanza


### PR DESCRIPTION
This reverts #136.

Introduced changes somehow broke the codeowner mechanism

