### PR TITLE
[#IP-455] Define pipelines for `io-functions-publiceventdispatcher` (fixes)

### DIFF
--- a/azure-devops/projects/io-backend-projects/io-functions-publiceventdispatcher.tf
+++ b/azure-devops/projects/io-backend-projects/io-functions-publiceventdispatcher.tf
@@ -2,7 +2,7 @@ variable "io-functions-publiceventdispatcher" {
   default = {
     repository = {
       organization   = "pagopa"
-      name           = "io-functions-publiceventdispatcher"
+      name           = "io-functions-public-event-dispatcher"
       branch_name    = "master"
       pipelines_path = ".devops"
     }


### PR DESCRIPTION
> This is the continuation of pagopa/gitops#152, which was erroneously merged and thus reverted in #154 

Repo: https://github.com/pagopa/io-functions-public-event-dispatcher
Resources: https://github.com/pagopa/io-infra/pull/11