### PR TITLE
Add renew service principal credential for PROD-IO

### DIFF
--- a/azure-devops/projects/io-backend-projects/locals.tf
+++ b/azure-devops/projects/io-backend-projects/locals.tf
@@ -1,6 +1,8 @@
 locals {
+  prefix                   = "io"
   key_vault_name           = "io-p-kv-azuredevops"
   key_vault_resource_group = "io-p-rg-operations"
   key_vault_subscription   = "PROD-IO"
   agent_pool               = "io-prod-linux"
+  tlscert_renew_token      = "v1"
 }

--- a/azure-devops/projects/io-backend-projects/provider.tf
+++ b/azure-devops/projects/io-backend-projects/provider.tf
@@ -23,3 +23,15 @@ terraform {
 provider "azurerm" {
   features {}
 }
+
+provider "azurerm" {
+  features {}
+  alias           = "prod-io"
+  subscription_id = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
+}
+
+provider "azurerm" {
+  features {}
+  alias           = "dev-io"
+  subscription_id = module.secrets.values["PAGOPAIT-DEV-IO-SUBSCRIPTION-ID"].value
+}

--- a/azure-devops/projects/io-backend-projects/service_connections.tf
+++ b/azure-devops/projects/io-backend-projects/service_connections.tf
@@ -108,11 +108,13 @@ module "PROD-IO-TLS-CERT-SERVICE-CONN" {
 }
 
 data "azurerm_key_vault" "kv_common" {
+  provider            = azurerm.prod-io
   name                = format("%s-p-kv-common", local.prefix)
   resource_group_name = format("%s-p-rg-common", local.prefix)
 }
 
 resource "azurerm_key_vault_access_policy" "PROD-IO-TLS-CERT-SERVICE-CONN_kv_common" {
+  provider     = azurerm.prod-io
   key_vault_id = data.azurerm_key_vault.kv_common.id
   tenant_id    = module.secrets.values["PAGOPAIT-TENANTID"].value
   object_id    = module.PROD-IO-TLS-CERT-SERVICE-CONN.service_principal_object_id
@@ -121,11 +123,13 @@ resource "azurerm_key_vault_access_policy" "PROD-IO-TLS-CERT-SERVICE-CONN_kv_com
 }
 
 data "azurerm_key_vault" "kv" {
+  provider            = azurerm.prod-io
   name                = format("%s-p-kv", local.prefix)
   resource_group_name = format("%s-p-sec-rg", local.prefix)
 }
 
 resource "azurerm_key_vault_access_policy" "PROD-IO-TLS-CERT-SERVICE-CONN_kv" {
+  provider     = azurerm.prod-io
   key_vault_id = data.azurerm_key_vault.kv.id
   tenant_id    = module.secrets.values["PAGOPAIT-TENANTID"].value
   object_id    = module.PROD-IO-TLS-CERT-SERVICE-CONN.service_principal_object_id

--- a/azure-devops/projects/io-backend-projects/tlscert-prod-api-app-internal-io-pagopa-it.tf
+++ b/azure-devops/projects/io-backend-projects/tlscert-prod-api-app-internal-io-pagopa-it.tf
@@ -11,7 +11,7 @@ variable "tlscert-prod-api-app-internal-io-pagopa-it" {
       path                    = "TLS-Certificates\\PROD"
       dns_record_name         = "api-app.internal"
       dns_zone_name           = "io.pagopa.it"
-      dns_zone_resource_group = "io-p-vnet-rg"
+      dns_zone_resource_group = "io-p-rg-external"
       # common variables to all pipelines
       variables = {
         CERT_NAME_EXPIRE_SECONDS = "2592000" #30 days
@@ -26,9 +26,8 @@ variable "tlscert-prod-api-app-internal-io-pagopa-it" {
 
 locals {
   tlscert-prod-api-app-internal-io-pagopa-it = {
-    tenant_id       = module.secrets.values["PAGOPAIT-TENANTID"].value
-    subscription_id = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
-
+    tenant_id         = module.secrets.values["PAGOPAIT-TENANTID"].value
+    subscription_id   = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
     subscription_name = "PROD-IO"
   }
   tlscert-prod-api-app-internal-io-pagopa-it-variables = {
@@ -39,12 +38,13 @@ locals {
 }
 
 module "tlscert-prod-api-app-internal-io-pagopa-it-cert_az" {
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.1"
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.2"
   count  = var.tlscert-prod-api-app-internal-io-pagopa-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = azuredevops_project.project.id
   repository                   = var.tlscert-prod-api-app-internal-io-pagopa-it.repository
   name                         = "${var.tlscert-prod-api-app-internal-io-pagopa-it.pipeline.dns_record_name}.${var.tlscert-prod-api-app-internal-io-pagopa-it.pipeline.dns_zone_name}"
+  renew_token                  = local.tlscert_renew_token
   path                         = var.tlscert-prod-api-app-internal-io-pagopa-it.pipeline.path
   github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id
 

--- a/azure-devops/projects/io-backend-projects/tlscert-prod-api-app-io-pagopa-it.tf
+++ b/azure-devops/projects/io-backend-projects/tlscert-prod-api-app-io-pagopa-it.tf
@@ -11,7 +11,7 @@ variable "tlscert-prod-api-app-io-pagopa-it" {
       path                    = "TLS-Certificates\\PROD"
       dns_record_name         = "api-app"
       dns_zone_name           = "io.pagopa.it"
-      dns_zone_resource_group = "io-p-vnet-rg"
+      dns_zone_resource_group = "io-p-rg-external"
       # common variables to all pipelines
       variables = {
         CERT_NAME_EXPIRE_SECONDS = "2592000" #30 days
@@ -26,7 +26,6 @@ variable "tlscert-prod-api-app-io-pagopa-it" {
 
 locals {
   tlscert-prod-api-app-io-pagopa-it = {
-
     tenant_id         = module.secrets.values["PAGOPAIT-TENANTID"].value
     subscription_id   = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
     subscription_name = "PROD-IO"
@@ -39,12 +38,13 @@ locals {
 }
 
 module "tlscert-prod-api-app-io-pagopa-it-cert_az" {
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.1"
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.2"
   count  = var.tlscert-prod-api-app-io-pagopa-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = azuredevops_project.project.id
   repository                   = var.tlscert-prod-api-app-io-pagopa-it.repository
   name                         = "${var.tlscert-prod-api-app-io-pagopa-it.pipeline.dns_record_name}.${var.tlscert-prod-api-app-io-pagopa-it.pipeline.dns_zone_name}"
+  renew_token                  = local.tlscert_renew_token
   path                         = var.tlscert-prod-api-app-io-pagopa-it.pipeline.path
   github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id
 

--- a/azure-devops/projects/io-backend-projects/tlscert-prod-api-gad-io-italia-it.tf
+++ b/azure-devops/projects/io-backend-projects/tlscert-prod-api-gad-io-italia-it.tf
@@ -11,7 +11,7 @@ variable "tlscert-prod-api-gad-io-italia-it" {
       path                    = "TLS-Certificates\\PROD"
       dns_record_name         = "api-gad"
       dns_zone_name           = "io.italia.it"
-      dns_zone_resource_group = "io-infra-rg"
+      dns_zone_resource_group = "io-p-rg-external"
       # common variables to all pipelines
       variables = {
         CERT_NAME_EXPIRE_SECONDS = "2592000" #30 days
@@ -27,11 +27,10 @@ variable "tlscert-prod-api-gad-io-italia-it" {
 locals {
   tlscert-prod-api-gad-io-italia-it = {
     tenant_id         = module.secrets.values["PAGOPAIT-TENANTID"].value
-    subscription_name = "PROD-IO"
     subscription_id   = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
+    subscription_name = "PROD-IO"
   }
   tlscert-prod-api-gad-io-italia-it-variables = {
-    KEY_VAULT_CERT_NAME          = "${replace(var.tlscert-prod-api-gad-io-italia-it.pipeline.dns_record_name, ".", "-")}-${replace(var.tlscert-prod-api-gad-io-italia-it.pipeline.dns_zone_name, ".", "-")}"
     KEY_VAULT_SERVICE_CONNECTION = module.PROD-IO-TLS-CERT-SERVICE-CONN.service_endpoint_name
   }
   tlscert-prod-api-gad-io-italia-it-variables_secret = {
@@ -39,12 +38,13 @@ locals {
 }
 
 module "tlscert-prod-api-gad-io-italia-it-cert_az" {
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.1"
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.2"
   count  = var.tlscert-prod-api-gad-io-italia-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = azuredevops_project.project.id
   repository                   = var.tlscert-prod-api-gad-io-italia-it.repository
   name                         = "${var.tlscert-prod-api-gad-io-italia-it.pipeline.dns_record_name}.${var.tlscert-prod-api-gad-io-italia-it.pipeline.dns_zone_name}"
+  renew_token                  = local.tlscert_renew_token
   path                         = var.tlscert-prod-api-gad-io-italia-it.pipeline.path
   github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id
 

--- a/azure-devops/projects/io-backend-projects/tlscert-prod-api-internal-io-italia-it.tf
+++ b/azure-devops/projects/io-backend-projects/tlscert-prod-api-internal-io-italia-it.tf
@@ -11,7 +11,7 @@ variable "tlscert-prod-api-internal-io-italia-it" {
       path                    = "TLS-Certificates\\PROD"
       dns_record_name         = "api-internal"
       dns_zone_name           = "io.italia.it"
-      dns_zone_resource_group = "io-infra-rg"
+      dns_zone_resource_group = "io-p-rg-external"
       # common variables to all pipelines
       variables = {
         CERT_NAME_EXPIRE_SECONDS = "2592000" #30 days
@@ -27,11 +27,10 @@ variable "tlscert-prod-api-internal-io-italia-it" {
 locals {
   tlscert-prod-api-internal-io-italia-it = {
     tenant_id         = module.secrets.values["PAGOPAIT-TENANTID"].value
-    subscription_name = "PROD-IO"
     subscription_id   = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
+    subscription_name = "PROD-IO"
   }
   tlscert-prod-api-internal-io-italia-it-variables = {
-    KEY_VAULT_CERT_NAME          = "${replace(var.tlscert-prod-api-internal-io-italia-it.pipeline.dns_record_name, ".", "-")}-${replace(var.tlscert-prod-api-internal-io-italia-it.pipeline.dns_zone_name, ".", "-")}"
     KEY_VAULT_SERVICE_CONNECTION = module.PROD-IO-TLS-CERT-SERVICE-CONN.service_endpoint_name
   }
   tlscert-prod-api-internal-io-italia-it-variables_secret = {
@@ -39,12 +38,13 @@ locals {
 }
 
 module "tlscert-prod-api-internal-io-italia-it-cert_az" {
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.1"
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.2"
   count  = var.tlscert-prod-api-internal-io-italia-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = azuredevops_project.project.id
   repository                   = var.tlscert-prod-api-internal-io-italia-it.repository
   name                         = "${var.tlscert-prod-api-internal-io-italia-it.pipeline.dns_record_name}.${var.tlscert-prod-api-internal-io-italia-it.pipeline.dns_zone_name}"
+  renew_token                  = local.tlscert_renew_token
   path                         = var.tlscert-prod-api-internal-io-italia-it.pipeline.path
   github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id
 

--- a/azure-devops/projects/io-backend-projects/tlscert-prod-api-io-italia-it.tf
+++ b/azure-devops/projects/io-backend-projects/tlscert-prod-api-io-italia-it.tf
@@ -11,7 +11,7 @@ variable "tlscert-prod-api-io-italia-it" {
       path                    = "TLS-Certificates\\PROD"
       dns_record_name         = "api"
       dns_zone_name           = "io.italia.it"
-      dns_zone_resource_group = "io-infra-rg"
+      dns_zone_resource_group = "io-p-rg-external"
       # common variables to all pipelines
       variables = {
         CERT_NAME_EXPIRE_SECONDS = "2592000" #30 days
@@ -27,11 +27,10 @@ variable "tlscert-prod-api-io-italia-it" {
 locals {
   tlscert-prod-api-io-italia-it = {
     tenant_id         = module.secrets.values["PAGOPAIT-TENANTID"].value
-    subscription_name = "PROD-IO"
     subscription_id   = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
+    subscription_name = "PROD-IO"
   }
   tlscert-prod-api-io-italia-it-variables = {
-    KEY_VAULT_CERT_NAME          = "${replace(var.tlscert-prod-api-io-italia-it.pipeline.dns_record_name, ".", "-")}-${replace(var.tlscert-prod-api-io-italia-it.pipeline.dns_zone_name, ".", "-")}"
     KEY_VAULT_SERVICE_CONNECTION = module.PROD-IO-TLS-CERT-SERVICE-CONN.service_endpoint_name
   }
   tlscert-prod-api-io-italia-it-variables_secret = {
@@ -39,12 +38,13 @@ locals {
 }
 
 module "tlscert-prod-api-io-italia-it-cert_az" {
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v1.1.0"
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.2"
   count  = var.tlscert-prod-api-io-italia-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = azuredevops_project.project.id
   repository                   = var.tlscert-prod-api-io-italia-it.repository
   name                         = "${var.tlscert-prod-api-io-italia-it.pipeline.dns_record_name}.${var.tlscert-prod-api-io-italia-it.pipeline.dns_zone_name}"
+  renew_token                  = local.tlscert_renew_token
   path                         = var.tlscert-prod-api-io-italia-it.pipeline.path
   github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id
 

--- a/azure-devops/projects/io-backend-projects/tlscert-prod-api-io-pagopa-it.tf
+++ b/azure-devops/projects/io-backend-projects/tlscert-prod-api-io-pagopa-it.tf
@@ -11,7 +11,7 @@ variable "tlscert-prod-api-io-pagopa-it" {
       path                    = "TLS-Certificates\\PROD"
       dns_record_name         = "api"
       dns_zone_name           = "io.pagopa.it"
-      dns_zone_resource_group = "io-p-vnet-rg"
+      dns_zone_resource_group = "io-p-rg-external"
       # common variables to all pipelines
       variables = {
         CERT_NAME_EXPIRE_SECONDS = "2592000" #30 days
@@ -26,9 +26,8 @@ variable "tlscert-prod-api-io-pagopa-it" {
 
 locals {
   tlscert-prod-api-io-pagopa-it = {
-    tenant_id       = module.secrets.values["PAGOPAIT-TENANTID"].value
-    subscription_id = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
-
+    tenant_id         = module.secrets.values["PAGOPAIT-TENANTID"].value
+    subscription_id   = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
     subscription_name = "PROD-IO"
   }
   tlscert-prod-api-io-pagopa-it-variables = {
@@ -39,12 +38,13 @@ locals {
 }
 
 module "tlscert-prod-api-io-pagopa-it-cert_az" {
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.1"
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.2"
   count  = var.tlscert-prod-api-io-pagopa-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = azuredevops_project.project.id
   repository                   = var.tlscert-prod-api-io-pagopa-it.repository
   name                         = "${var.tlscert-prod-api-io-pagopa-it.pipeline.dns_record_name}.${var.tlscert-prod-api-io-pagopa-it.pipeline.dns_zone_name}"
+  renew_token                  = local.tlscert_renew_token
   path                         = var.tlscert-prod-api-io-pagopa-it.pipeline.path
   github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id
 

--- a/azure-devops/projects/io-backend-projects/tlscert-prod-api-mtls-io-pagopa-it.tf
+++ b/azure-devops/projects/io-backend-projects/tlscert-prod-api-mtls-io-pagopa-it.tf
@@ -11,7 +11,7 @@ variable "tlscert-prod-api-mtls-io-pagopa-it" {
       path                    = "TLS-Certificates\\PROD"
       dns_record_name         = "api-mtls"
       dns_zone_name           = "io.pagopa.it"
-      dns_zone_resource_group = "io-p-vnet-rg"
+      dns_zone_resource_group = "io-p-rg-external"
       # common variables to all pipelines
       variables = {
         CERT_NAME_EXPIRE_SECONDS = "2592000" #30 days
@@ -26,9 +26,8 @@ variable "tlscert-prod-api-mtls-io-pagopa-it" {
 
 locals {
   tlscert-prod-api-mtls-io-pagopa-it = {
-    tenant_id       = module.secrets.values["PAGOPAIT-TENANTID"].value
-    subscription_id = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
-
+    tenant_id         = module.secrets.values["PAGOPAIT-TENANTID"].value
+    subscription_id   = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
     subscription_name = "PROD-IO"
   }
   tlscert-prod-api-mtls-io-pagopa-it-variables = {
@@ -39,12 +38,13 @@ locals {
 }
 
 module "tlscert-prod-api-mtls-io-pagopa-it-cert_az" {
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.1"
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.2"
   count  = var.tlscert-prod-api-mtls-io-pagopa-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = azuredevops_project.project.id
   repository                   = var.tlscert-prod-api-mtls-io-pagopa-it.repository
   name                         = "${var.tlscert-prod-api-mtls-io-pagopa-it.pipeline.dns_record_name}.${var.tlscert-prod-api-mtls-io-pagopa-it.pipeline.dns_zone_name}"
+  renew_token                  = local.tlscert_renew_token
   path                         = var.tlscert-prod-api-mtls-io-pagopa-it.pipeline.path
   github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id
 

--- a/azure-devops/projects/io-backend-projects/tlscert-prod-app-backend-io-italia-it.tf
+++ b/azure-devops/projects/io-backend-projects/tlscert-prod-app-backend-io-italia-it.tf
@@ -11,7 +11,7 @@ variable "tlscert-prod-app-backend-io-italia-it" {
       path                    = "TLS-Certificates\\PROD"
       dns_record_name         = "app-backend"
       dns_zone_name           = "io.italia.it"
-      dns_zone_resource_group = "io-infra-rg"
+      dns_zone_resource_group = "io-p-rg-external"
       # common variables to all pipelines
       variables = {
         CERT_NAME_EXPIRE_SECONDS = "2592000" #30 days
@@ -27,11 +27,10 @@ variable "tlscert-prod-app-backend-io-italia-it" {
 locals {
   tlscert-prod-app-backend-io-italia-it = {
     tenant_id         = module.secrets.values["PAGOPAIT-TENANTID"].value
-    subscription_name = "PROD-IO"
     subscription_id   = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
+    subscription_name = "PROD-IO"
   }
   tlscert-prod-app-backend-io-italia-it-variables = {
-    KEY_VAULT_CERT_NAME          = "${replace(var.tlscert-prod-app-backend-io-italia-it.pipeline.dns_record_name, ".", "-")}-${replace(var.tlscert-prod-app-backend-io-italia-it.pipeline.dns_zone_name, ".", "-")}"
     KEY_VAULT_SERVICE_CONNECTION = module.PROD-IO-TLS-CERT-SERVICE-CONN.service_endpoint_name
   }
   tlscert-prod-app-backend-io-italia-it-variables_secret = {
@@ -39,12 +38,13 @@ locals {
 }
 
 module "tlscert-prod-app-backend-io-italia-it-cert_az" {
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v1.1.0"
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.2"
   count  = var.tlscert-prod-app-backend-io-italia-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = azuredevops_project.project.id
   repository                   = var.tlscert-prod-app-backend-io-italia-it.repository
   name                         = "${var.tlscert-prod-app-backend-io-italia-it.pipeline.dns_record_name}.${var.tlscert-prod-app-backend-io-italia-it.pipeline.dns_zone_name}"
+  renew_token                  = local.tlscert_renew_token
   path                         = var.tlscert-prod-app-backend-io-italia-it.pipeline.path
   github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id
 

--- a/azure-devops/projects/io-backend-projects/tlscert-prod-developerportal-backend-io-italia-it.tf
+++ b/azure-devops/projects/io-backend-projects/tlscert-prod-developerportal-backend-io-italia-it.tf
@@ -11,7 +11,7 @@ variable "tlscert-prod-developerportal-backend-io-italia-it" {
       path                    = "TLS-Certificates\\PROD"
       dns_record_name         = "developerportal-backend"
       dns_zone_name           = "io.italia.it"
-      dns_zone_resource_group = "io-infra-rg"
+      dns_zone_resource_group = "io-p-rg-external"
       # common variables to all pipelines
       variables = {
         CERT_NAME_EXPIRE_SECONDS = "2592000" #30 days
@@ -27,11 +27,10 @@ variable "tlscert-prod-developerportal-backend-io-italia-it" {
 locals {
   tlscert-prod-developerportal-backend-io-italia-it = {
     tenant_id         = module.secrets.values["PAGOPAIT-TENANTID"].value
-    subscription_name = "PROD-IO"
     subscription_id   = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
+    subscription_name = "PROD-IO"
   }
   tlscert-prod-developerportal-backend-io-italia-it-variables = {
-    KEY_VAULT_CERT_NAME          = "${replace(var.tlscert-prod-developerportal-backend-io-italia-it.pipeline.dns_record_name, ".", "-")}-${replace(var.tlscert-prod-developerportal-backend-io-italia-it.pipeline.dns_zone_name, ".", "-")}"
     KEY_VAULT_SERVICE_CONNECTION = module.PROD-IO-TLS-CERT-SERVICE-CONN.service_endpoint_name
   }
   tlscert-prod-developerportal-backend-io-italia-it-variables_secret = {
@@ -39,12 +38,13 @@ locals {
 }
 
 module "tlscert-prod-developerportal-backend-io-italia-it-cert_az" {
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v1.1.0"
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.2"
   count  = var.tlscert-prod-developerportal-backend-io-italia-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = azuredevops_project.project.id
   repository                   = var.tlscert-prod-developerportal-backend-io-italia-it.repository
   name                         = "${var.tlscert-prod-developerportal-backend-io-italia-it.pipeline.dns_record_name}.${var.tlscert-prod-developerportal-backend-io-italia-it.pipeline.dns_zone_name}"
+  renew_token                  = local.tlscert_renew_token
   path                         = var.tlscert-prod-developerportal-backend-io-italia-it.pipeline.path
   github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id
 

--- a/azure-devops/projects/io-backend-projects/tlscert-prod-io-italia-it.tf
+++ b/azure-devops/projects/io-backend-projects/tlscert-prod-io-italia-it.tf
@@ -1,0 +1,75 @@
+variable "tlscert-prod-io-italia-it" {
+  default = {
+    repository = {
+      organization   = "pagopa"
+      name           = "le-azure-acme-tiny"
+      branch_name    = "master"
+      pipelines_path = "."
+    }
+    pipeline = {
+      enable_tls_cert         = true
+      path                    = "TLS-Certificates\\PROD"
+      dns_record_name         = ""
+      dns_zone_name           = "io.italia.it"
+      dns_zone_resource_group = "io-p-rg-external"
+      # common variables to all pipelines
+      variables = {
+        CERT_NAME_EXPIRE_SECONDS = "2592000" #30 days
+        KEY_VAULT_NAME           = "io-p-kv-common"
+      }
+      # common secret variables to all pipelines
+      variables_secret = {
+      }
+    }
+  }
+}
+
+locals {
+  tlscert-prod-io-italia-it = {
+    tenant_id         = module.secrets.values["PAGOPAIT-TENANTID"].value
+    subscription_id   = module.secrets.values["PAGOPAIT-PROD-IO-SUBSCRIPTION-ID"].value
+    subscription_name = "PROD-IO"
+  }
+  tlscert-prod-io-italia-it-variables = {
+    KEY_VAULT_SERVICE_CONNECTION = module.PROD-IO-TLS-CERT-SERVICE-CONN.service_endpoint_name
+  }
+  tlscert-prod-io-italia-it-variables_secret = {
+  }
+}
+
+module "tlscert-prod-io-italia-it-cert_az" {
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert?ref=v2.0.2"
+  count  = var.tlscert-prod-io-italia-it.pipeline.enable_tls_cert == true ? 1 : 0
+
+  project_id                   = azuredevops_project.project.id
+  repository                   = var.tlscert-prod-io-italia-it.repository
+  name                         = "${var.tlscert-prod-io-italia-it.pipeline.dns_record_name}.${var.tlscert-prod-io-italia-it.pipeline.dns_zone_name}"
+  renew_token                  = local.tlscert_renew_token
+  path                         = var.tlscert-prod-io-italia-it.pipeline.path
+  github_service_connection_id = azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id
+
+  dns_record_name         = var.tlscert-prod-io-italia-it.pipeline.dns_record_name
+  dns_zone_name           = var.tlscert-prod-io-italia-it.pipeline.dns_zone_name
+  dns_zone_resource_group = var.tlscert-prod-io-italia-it.pipeline.dns_zone_resource_group
+  tenant_id               = local.tlscert-prod-io-italia-it.tenant_id
+  subscription_name       = local.tlscert-prod-io-italia-it.subscription_name
+  subscription_id         = local.tlscert-prod-io-italia-it.subscription_id
+
+  credential_subcription              = local.key_vault_subscription
+  credential_key_vault_name           = local.key_vault_name
+  credential_key_vault_resource_group = local.key_vault_resource_group
+
+  variables = merge(
+    var.tlscert-prod-io-italia-it.pipeline.variables,
+    local.tlscert-prod-io-italia-it-variables,
+  )
+
+  variables_secret = merge(
+    var.tlscert-prod-io-italia-it.pipeline.variables_secret,
+    local.tlscert-prod-io-italia-it-variables_secret,
+  )
+
+  service_connection_ids_authorization = [
+    module.PROD-IO-TLS-CERT-SERVICE-CONN.service_endpoint_id,
+  ]
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

1. add renew service principal credential
2. manage keyvault permission inside service connetion (no more need to manage it in infrastructure repo)

How to renew service principal credentials? just change `tlscert_renew_token` and apply

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
