### PR TITLE
[CEN-1021] Allow deployment of Batch Acquirer in cstar DEV environment

### DIFF
--- a/azure-devops/projects/cstar-projects/rtd-ms-transaction-filter.tf
+++ b/azure-devops/projects/cstar-projects/rtd-ms-transaction-filter.tf
@@ -36,12 +36,20 @@ locals {
   }
   # deploy vars
   rtd-ms-transaction-filter-variables_deploy = {
-
+    k8s_image_repository_name            = replace(var.rtd-ms-transaction-filter.repository.name, "-", "")
+    deploy_namespace                     = "fa"
+    settings_xml_rw_secure_file_name     = "settings-rw.xml"
+    settings_xml_ro_secure_file_name     = "settings-ro.xml"
+    dev_container_registry_service_conn  = azuredevops_serviceendpoint_azurecr.cstar-azurecr-dev.service_endpoint_name
+    dev_kubernetes_service_conn          = azuredevops_serviceendpoint_kubernetes.cstar-aks-dev.service_endpoint_name
+    dev_container_registry_name          = "cstardacr.azurecr.io"
+    dev_agent_pool                       = "cstar-dev-linux"
   }
   # deploy secrets
   rtd-ms-transaction-filter-variables_secret_deploy = {
 
   }
+
 }
 
 module "rtd-ms-transaction-filter_code_review" {
@@ -92,5 +100,8 @@ module "rtd-ms-transaction-filter_deploy" {
 
   service_connection_ids_authorization = [
     azuredevops_serviceendpoint_github.io-azure-devops-github-ro.id,
+    azuredevops_serviceendpoint_azurerm.DEV-CSTAR.id,
+    azuredevops_serviceendpoint_azurecr.cstar-azurecr-dev.id,
+    azuredevops_serviceendpoint_kubernetes.cstar-aks-dev.id
   ]
 }


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to to allow the deployment of batch acquirer in cstar dev environment, as a POD in the k8s cluster.

### List of changes

<!--- Describe your changes in detail -->
-Variables and service connection to allow the deployment in dev cluster

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change is motivated by the need to test the batch acquirer in a controlled environment

### Type of changes

- [ ] Add new pipeline
- [X] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
