### PR TITLE
[#IC-148] Allow parallel deploy of both `DevPortal` and `SelfCare IO`

### DIFF
--- a/azure-devops/projects/io-developer-portal-projects/io-developer-portal-backend.tf
+++ b/azure-devops/projects/io-developer-portal-projects/io-developer-portal-backend.tf
@@ -12,6 +12,10 @@ variable "io-developer-portal-backend" {
         web_app_name                = "io-p-app-developerportalbackend"
         web_app_resource_group_name = "io-p-rg-internal"
       }
+      selfcare_prod = {
+        web_app_name                = "io-p-app-selfcarebackend"
+        web_app_resource_group_name = "io-p-rg-selfcare"
+      }
     }
   }
 }
@@ -152,6 +156,18 @@ resource "azuredevops_build_definition" "io-developer-portal-backend-deploy" {
   variable {
     name           = "PROD_WEB_APP_RESOURCE_GROUP_NAME"
     value          = var.io-developer-portal-backend.pipeline.prod.web_app_resource_group_name
+    allow_override = false
+  }
+
+  variable {
+    name           = "SELFCARE_PROD_WEB_APP_NAME"
+    value          = var.io-developer-portal-backend.pipeline.selfcare_prod.web_app_name
+    allow_override = false
+  }
+
+  variable {
+    name           = "SELFCARE_PROD_WEB_APP_RESOURCE_GROUP_NAME"
+    value          = var.io-developer-portal-backend.pipeline.selfcare_prod.web_app_resource_group_name
     allow_override = false
   }
 

--- a/azure-devops/projects/io-developer-portal-projects/io-developer-portal-backend.tf
+++ b/azure-devops/projects/io-developer-portal-projects/io-developer-portal-backend.tf
@@ -9,7 +9,6 @@ variable "io-developer-portal-backend" {
     pipeline = {
       cache_version_id = "v1"
       prod = {
-        deploy_type                 = "production_slot" #or staging_slot_and_swap
         web_app_name                = "io-p-app-developerportalbackend"
         web_app_resource_group_name = "io-p-rg-internal"
       }
@@ -141,12 +140,6 @@ resource "azuredevops_build_definition" "io-developer-portal-backend-deploy" {
   variable {
     name           = "PROD_AZURE_SUBSCRIPTION"
     value          = azuredevops_serviceendpoint_azurerm.PROD-IO.service_endpoint_name
-    allow_override = false
-  }
-
-  variable {
-    name           = "PROD_DEPLOY_TYPE"
-    value          = var.io-developer-portal-backend.pipeline.prod.deploy_type
     allow_override = false
   }
 

--- a/azure-devops/projects/io-developer-portal-projects/io-developer-portal-backend.tf
+++ b/azure-devops/projects/io-developer-portal-projects/io-developer-portal-backend.tf
@@ -8,11 +8,6 @@ variable "io-developer-portal-backend" {
     }
     pipeline = {
       cache_version_id = "v1"
-      dev = {
-        deploy_type                 = "production_slot" #or staging_slot_and_swap
-        web_app_name                = ""
-        web_app_resource_group_name = ""
-      }
       prod = {
         deploy_type                 = "production_slot" #or staging_slot_and_swap
         web_app_name                = "io-p-app-developerportalbackend"
@@ -150,20 +145,8 @@ resource "azuredevops_build_definition" "io-developer-portal-backend-deploy" {
   }
 
   variable {
-    name           = "DEV_AZURE_SUBSCRIPTION"
-    value          = ""
-    allow_override = false
-  }
-
-  variable {
     name           = "PROD_DEPLOY_TYPE"
     value          = var.io-developer-portal-backend.pipeline.prod.deploy_type
-    allow_override = false
-  }
-
-  variable {
-    name           = "DEV_DEPLOY_TYPE"
-    value          = var.io-developer-portal-backend.pipeline.dev.deploy_type
     allow_override = false
   }
 
@@ -174,20 +157,8 @@ resource "azuredevops_build_definition" "io-developer-portal-backend-deploy" {
   }
 
   variable {
-    name           = "DEV_WEB_APP_NAME"
-    value          = var.io-developer-portal-backend.pipeline.dev.web_app_name
-    allow_override = false
-  }
-
-  variable {
     name           = "PROD_WEB_APP_RESOURCE_GROUP_NAME"
     value          = var.io-developer-portal-backend.pipeline.prod.web_app_resource_group_name
-    allow_override = false
-  }
-
-  variable {
-    name           = "DEV_RESOURCE_GROUP_NAME"
-    value          = var.io-developer-portal-backend.pipeline.dev.web_app_resource_group_name
     allow_override = false
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
See commit list

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
`DevPortal` and `SelfCare IO` will share the same codebase although deploy to different instances

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
