### PR TITLE
[CEN-1562] modify github token to use cstar-github-bot

### DIFF
--- a/azure-devops/projects/cstar-iac-projects/secrets.tf
+++ b/azure-devops/projects/cstar-iac-projects/secrets.tf
@@ -5,8 +5,8 @@ module "secrets" {
   key_vault_name = local.key_vault_name
 
   secrets = [
-    "io-azure-devops-github-ro-TOKEN",
-    "io-azure-devops-github-pr-TOKEN",
+    "cstar-azure-devops-github-ro-TOKEN",
+    "cstar-azure-devops-github-pr-TOKEN",
     "PAGOPAIT-TENANTID",
     "PAGOPAIT-DEV-CSTAR-SUBSCRIPTION-ID",
     "PAGOPAIT-UAT-CSTAR-SUBSCRIPTION-ID",

--- a/azure-devops/projects/cstar-iac-projects/service_connections.tf
+++ b/azure-devops/projects/cstar-iac-projects/service_connections.tf
@@ -1,11 +1,11 @@
 # Github service connection (read-only)
-resource "azuredevops_serviceendpoint_github" "io-azure-devops-github-ro" {
+resource "azuredevops_serviceendpoint_github" "cstar-azure-devops-github-ro" {
   depends_on = [azuredevops_project.project]
 
   project_id            = azuredevops_project.project.id
   service_endpoint_name = "io-azure-devops-github-ro"
   auth_personal {
-    personal_access_token = module.secrets.values["io-azure-devops-github-ro-TOKEN"].value
+    personal_access_token = module.secrets.values["cstar-azure-devops-github-ro-TOKEN"].value
   }
   lifecycle {
     ignore_changes = [description, authorization]
@@ -13,13 +13,13 @@ resource "azuredevops_serviceendpoint_github" "io-azure-devops-github-ro" {
 }
 
 # Github service connection (pull request)
-resource "azuredevops_serviceendpoint_github" "io-azure-devops-github-pr" {
+resource "azuredevops_serviceendpoint_github" "cstar-azure-devops-github-pr" {
   depends_on = [azuredevops_project.project]
 
   project_id            = azuredevops_project.project.id
   service_endpoint_name = "io-azure-devops-github-pr"
   auth_personal {
-    personal_access_token = module.secrets.values["io-azure-devops-github-pr-TOKEN"].value
+    personal_access_token = module.secrets.values["cstar-azure-devops-github-pr-TOKEN"].value
   }
   lifecycle {
     ignore_changes = [description, authorization]

--- a/azure-devops/projects/cstar-iac-projects/service_connections.tf
+++ b/azure-devops/projects/cstar-iac-projects/service_connections.tf
@@ -1,5 +1,5 @@
 # Github service connection (read-only)
-resource "azuredevops_serviceendpoint_github" "cstar-azure-devops-github-ro" {
+resource "azuredevops_serviceendpoint_github" "io-azure-devops-github-ro" {
   depends_on = [azuredevops_project.project]
 
   project_id            = azuredevops_project.project.id
@@ -13,7 +13,7 @@ resource "azuredevops_serviceendpoint_github" "cstar-azure-devops-github-ro" {
 }
 
 # Github service connection (pull request)
-resource "azuredevops_serviceendpoint_github" "cstar-azure-devops-github-pr" {
+resource "azuredevops_serviceendpoint_github" "io-azure-devops-github-pr" {
   depends_on = [azuredevops_project.project]
 
   project_id            = azuredevops_project.project.id

--- a/azure-devops/projects/cstar-projects/secrets.tf
+++ b/azure-devops/projects/cstar-projects/secrets.tf
@@ -5,8 +5,8 @@ module "secrets" {
   key_vault_name = "io-p-kv-azuredevops"
 
   secrets = [
-    "io-azure-devops-github-ro-TOKEN",
-    "io-azure-devops-github-pr-TOKEN",
+    "cstar-azure-devops-github-ro-TOKEN",
+    "cstar-azure-devops-github-pr-TOKEN",
     "PAGOPAIT-TENANTID",
     "PAGOPAIT-DEV-CSTAR-SUBSCRIPTION-ID",
     "PAGOPAIT-UAT-CSTAR-SUBSCRIPTION-ID",

--- a/azure-devops/projects/cstar-projects/service_connections.tf
+++ b/azure-devops/projects/cstar-projects/service_connections.tf
@@ -1,11 +1,11 @@
 # Github service connection (read-only)
-resource "azuredevops_serviceendpoint_github" "io-azure-devops-github-ro" {
+resource "azuredevops_serviceendpoint_github" "cstar-azure-devops-github-ro" {
   depends_on = [azuredevops_project.project]
 
   project_id            = azuredevops_project.project.id
   service_endpoint_name = "io-azure-devops-github-ro"
   auth_personal {
-    personal_access_token = module.secrets.values["io-azure-devops-github-ro-TOKEN"].value
+    personal_access_token = module.secrets.values["cstar-azure-devops-github-io-TOKEN"].value
   }
   lifecycle {
     ignore_changes = [description, authorization]
@@ -13,13 +13,13 @@ resource "azuredevops_serviceendpoint_github" "io-azure-devops-github-ro" {
 }
 
 # Github service connection (pull request)
-resource "azuredevops_serviceendpoint_github" "io-azure-devops-github-pr" {
+resource "azuredevops_serviceendpoint_github" "cstar-azure-devops-github-pr" {
   depends_on = [azuredevops_project.project]
 
   project_id            = azuredevops_project.project.id
   service_endpoint_name = "io-azure-devops-github-pr"
   auth_personal {
-    personal_access_token = module.secrets.values["io-azure-devops-github-pr-TOKEN"].value
+    personal_access_token = module.secrets.values["cstar-azure-devops-github-pr-TOKEN"].value
   }
   lifecycle {
     ignore_changes = [description, authorization]

--- a/azure-devops/projects/cstar-projects/service_connections.tf
+++ b/azure-devops/projects/cstar-projects/service_connections.tf
@@ -1,11 +1,11 @@
 # Github service connection (read-only)
-resource "azuredevops_serviceendpoint_github" "cstar-azure-devops-github-ro" {
+resource "azuredevops_serviceendpoint_github" "io-azure-devops-github-ro" {
   depends_on = [azuredevops_project.project]
 
   project_id            = azuredevops_project.project.id
   service_endpoint_name = "io-azure-devops-github-ro"
   auth_personal {
-    personal_access_token = module.secrets.values["cstar-azure-devops-github-io-TOKEN"].value
+    personal_access_token = module.secrets.values["cstar-azure-devops-github-ro-TOKEN"].value
   }
   lifecycle {
     ignore_changes = [description, authorization]
@@ -13,7 +13,7 @@ resource "azuredevops_serviceendpoint_github" "cstar-azure-devops-github-ro" {
 }
 
 # Github service connection (pull request)
-resource "azuredevops_serviceendpoint_github" "cstar-azure-devops-github-pr" {
+resource "azuredevops_serviceendpoint_github" "io-azure-devops-github-pr" {
   depends_on = [azuredevops_project.project]
 
   project_id            = azuredevops_project.project.id


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to modify the token used by cstar service connection to use the `cstar-github-bot` 

### List of changes

<!--- Describe your changes in detail -->
- rename the secrets containing bot token
- rename the azure modules which create the service connections

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Comply with devops guidelines reported here
https://pagopa.atlassian.net/wiki/spaces/DEVOPS/pages/466716501/Github+-+bots+for+projects

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
