### PR TITLE
[RTD-83] fix refuse in terraform files for ingestor and decrypter

### DIFF
--- a/azure-devops/projects/cstar-projects/rtd-ms-decrypt.tf
+++ b/azure-devops/projects/cstar-projects/rtd-ms-decrypt.tf
@@ -17,7 +17,7 @@ variable "rtd-ms-decrypter" {
 locals {
   # global vars
   rtd-ms-decrypter-variables = {
-    dockerfile = "DockerfileV1"
+    dockerfile = "Dockerfile"
   }
   # global secrets
   rtd-ms-decrypter-variables_secret = {

--- a/azure-devops/projects/cstar-projects/rtd-ms-ingestor.tf
+++ b/azure-devops/projects/cstar-projects/rtd-ms-ingestor.tf
@@ -3,7 +3,7 @@ variable "rtd-ms-ingestor" {
     repository = {
       organization    = "pagopa"
       name            = "rtd-ms-ingestor"
-      branch_name     = "master"
+      branch_name     = "main"
       pipelines_path  = ".devops"
       yml_prefix_name = null
     }
@@ -17,7 +17,7 @@ variable "rtd-ms-ingestor" {
 locals {
   # global vars
   rtd-ms-ingestor-variables = {
-    dockerfile = "DockerfileV1"
+    dockerfile = "Dockerfile"
   }
   # global secrets
   rtd-ms-ingestor-variables_secret = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR propose a fix for refuses in rtd-ms-decrypter and rtd-ms-ingestor terraform files.
### List of changes

<!--- Describe your changes in detail -->
- In the rtd-ms-ingestor file the branch has been set to "main" instead of "master".
- In both rtd-ms-decrypter and rtd-ms-ingestor the suffix "V1" to the dockerfile name has been removed.
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
There was typos inherited from the migration of Cstar.
### Type of changes

- [ ] Add new pipeline
- [ ] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
